### PR TITLE
updated grep bug

### DIFF
--- a/amplicov/amplicov
+++ b/amplicov/amplicov
@@ -121,7 +121,7 @@ def convert_bedpe_to_amplicon_dict(input,cov_array,RefID="",unique=False, count_
     amplicon=defaultdict(dict)
     primers_pos=list()
     RefID = '""' if RefID is None else RefID
-    cmd = 'grep %s %s | cut -f 2,3,5,6,7 ' % (RefID, input_bedpe)
+    cmd = 'grep -w %s %s | cut -f 2,3,5,6,7 ' % (RefID, input_bedpe)
     proc = subprocess.Popen(cmd,shell=True,stdout=subprocess.PIPE) 
     previous_id=''
     outs, errs = proc.communicate()


### PR DESCRIPTION
If one reference name is a substring of another, e.g. RSV_A and RSV_AD, then amplicov will pull the RSV_AD primer locations along with RSV_A primer locations. The reason is that

 Line 124 in Amplidov: cmd = 'grep %s %s | cut -f 2,3,5,6,7 ' % (RefID, input_bedpe) 

used a default grep, which does not do exact matching.